### PR TITLE
small housekeeping changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Merge
+name: ci
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PostgreSQL Wire Protocol
 
-<!-- ![Merge](https://github.com/alex-dukhno/) -->
-<!-- [![Coverage Status](https://coveralls.io/repos/github/alex-dukhno/database/badge.svg?branch=master)](https://coveralls.io/github/alex-dukhno/database?branch=master) -->
+![ci](https://github.com/alex-dukhno/pg_wire/workflows/ci/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/alex-dukhno/pg_wire/badge.svg?branch=main)](https://coveralls.io/github/alex-dukhno/pg_wire?branch=main)
 <a href="https://discord.gg/PUcTcfU"><img src="https://img.shields.io/discord/509773073294295082.svg?logo=discord"></a>
 
 ## Development

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ mod messages;
 /// Connection key-value params
 pub type ClientParams = Vec<(String, String)>;
 /// Protocol operation result
-pub type ProtocolResult<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// PostgreSQL OID [Object Identifier](https://www.postgresql.org/docs/current/datatype-oid.html)
 pub(crate) type Oid = u32;
@@ -132,7 +132,7 @@ pub enum PgFormat {
 impl TryFrom<i16> for PgFormat {
     type Error = UnrecognizedFormat;
 
-    fn try_from(value: i16) -> Result<Self, Self::Error> {
+    fn try_from(value: i16) -> std::result::Result<Self, Self::Error> {
         match value {
             0 => Ok(PgFormat::Text),
             1 => Ok(PgFormat::Binary),


### PR DESCRIPTION
rename `ProtocolResult` to `Result`
use `Result` from standard library explicitly as `std::result::Result`
rename `Merge` workflow to `ci`