### PR TITLE
use std convert api for Error conversions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: tarpaulin
-          args: -o Lcov --output-dir ./coverage
+          args: --all --ignore-tests -o Lcov --output-dir ./coverage
       - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/format.rs
+++ b/src/format.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::Error;
 use std::convert::TryFrom;
 
 /// PostgreSQL formats for transferring data
@@ -27,24 +26,28 @@ pub enum PgFormat {
 }
 
 impl TryFrom<i16> for PgFormat {
-    type Error = UnrecognizedFormat;
+    type Error = crate::Error;
 
-    fn try_from(value: i16) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: i16) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(PgFormat::Text),
             1 => Ok(PgFormat::Binary),
-            other => Err(UnrecognizedFormat(other)),
+            other => Err(UnrecognizedFormat(other).into()),
         }
     }
 }
 
 /// Represents an error if frontend sent unrecognizable format
 /// contains the integer code that was sent
-#[derive(Debug)]
-pub struct UnrecognizedFormat(pub(crate) i16);
+#[derive(Debug, PartialEq)]
+pub(crate) struct UnrecognizedFormat(pub(crate) i16);
 
-impl From<UnrecognizedFormat> for Error {
-    fn from(error: UnrecognizedFormat) -> Error {
-        Error::InvalidInput(format!("unknown format code: {}", error.0))
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unrecognized_format() {
+        assert_eq!(PgFormat::try_from(2), Err(UnrecognizedFormat(2).into()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 #![warn(missing_docs)]
 //! API for backend implementation of PostgreSQL Wire Protocol
 
-pub use format::{PgFormat, UnrecognizedFormat};
+pub use format::PgFormat;
 pub use hand_shake::{Process as HandShakeProcess, Request as HandShakeRequest, Status as HandShakeStatus};
 pub use message_decoder::{MessageDecoder, Status as MessageDecoderStatus};
 pub use messages::{BackendMessage, ColumnMetadata, FrontendMessage};

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -423,10 +423,7 @@ fn decode_bind(mut cursor: Cursor) -> Result<FrontendMessage> {
 }
 
 fn decode_format(cursor: &mut Cursor) -> Result<PgFormat> {
-    match PgFormat::try_from(cursor.read_i16()?) {
-        Ok(format) => Ok(format),
-        Err(error) => Err(error.into()),
-    }
+    PgFormat::try_from(cursor.read_i16()?).map_err(Into::into)
 }
 
 fn decode_close(mut cursor: Cursor) -> Result<FrontendMessage> {

--- a/src/result.rs
+++ b/src/result.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::types::NotSupportedOid;
+use crate::{format::UnrecognizedFormat, types::NotSupportedOid};
+use std::num::ParseIntError;
 
 /// Protocol operation result
 pub type Result<T> = std::result::Result<T, Error>;
@@ -43,5 +44,47 @@ pub enum Error {
 impl From<NotSupportedOid> for Error {
     fn from(error: NotSupportedOid) -> Error {
         Error::InvalidInput(error.to_string())
+    }
+}
+
+impl From<UnrecognizedFormat> for Error {
+    fn from(error: UnrecognizedFormat) -> Error {
+        Error::InvalidInput(format!("unknown format code: {}", error.0))
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(error: ParseIntError) -> Self {
+        Error::InvalidInput(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod error_conversion {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn from_not_supported_oid() {
+        assert_eq!(
+            Error::from(NotSupportedOid(100)),
+            Error::InvalidInput("100 OID is not supported".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_unrecognized_format() {
+        assert_eq!(
+            Error::from(UnrecognizedFormat(100)),
+            Error::InvalidInput("unknown format code: 100".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_parse_int_error() {
+        assert_eq!(
+            Error::from(i32::from_str("1.2").unwrap_err()),
+            Error::InvalidInput("invalid digit found in string".to_owned())
+        );
     }
 }


### PR DESCRIPTION
* use `crate::Error` as public API error to report problems
* implement `From` trait for `crate::Error` to convert into it from other std or crate errors
* simplify `parse_` functions